### PR TITLE
fix: add version number in app name to workaround liberty bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN installUtility install --acceptLicense defaultServer
 
 # Upgrade to production license if URL to JAR provided
 ARG LICENSE_JAR_URL
-RUN \ 
+RUN \
   if [ $LICENSE_JAR_URL ]; then \
     wget $LICENSE_JAR_URL -O /tmp/license.jar \
     && java -jar /tmp/license.jar -acceptLicense /opt/ibm \

--- a/src/main/liberty/config/server.xml
+++ b/src/main/liberty/config/server.xml
@@ -15,6 +15,6 @@
 
   <applicationMonitor pollingRate="1000ms"/>
 
-  <webApplication name="javalibertymicroservice" location="${app.location}" contextRoot="/"/>
+  <webApplication name="javalibertymicroservice-1.0-SNAPSHOT" location="${app.location}" contextRoot="/"/>
 
 </server>


### PR DESCRIPTION
Also remove trailing spaces from docker files which can cause a toolchain containerize failure.